### PR TITLE
[DC] [90531148] Count every gallery navigation click.

### DIFF
--- a/app/coffeescript/components/ui/gallery.coffee
+++ b/app/coffeescript/components/ui/gallery.coffee
@@ -18,7 +18,9 @@ define [
     @initSwiper = ->
       # swiperConfig is set here due to the fact that @defaultAttrs can be
       # clobbered when multiple instances of a component are initialized.
-      swiperConfig = { speed: 150 }
+      # Navigation clicks are not counted during the transition. Raising the
+      # speed may result in missed clicks.
+      swiperConfig = { speed: 125 }
       for key, value of @attr.swiperConfig
         swiperConfig[key] = value
 

--- a/dist/components/ui/gallery.js
+++ b/dist/components/ui/gallery.js
@@ -6,7 +6,7 @@ define(['jquery', 'flight/lib/component', 'swiper'], function($, defineComponent
     this.initSwiper = function() {
       var key, ref, swiperConfig, value;
       swiperConfig = {
-        speed: 150
+        speed: 125
       };
       ref = this.attr.swiperConfig;
       for (key in ref) {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/90531148

The default is 300 ms. At 150 ms, there is still has an obvious transition, and I am unable to click fast enough to not have the slides change.
