### PR TITLE
[CW] [91500142] Fix lazy load

### DIFF
--- a/app/coffeescript/components/ui/image_loader.coffee
+++ b/app/coffeescript/components/ui/image_loader.coffee
@@ -16,11 +16,8 @@ define [
       # when uiGalleryLazyLoadRequested is received.
       lazyLoadThreshold: undefined
 
-    @initialLoad = ->
-      @loadImages(@attr.lazyLoadThreshold)
-
     @lazyLoad = ->
-      @loadImages()
+      @loadImages(@attr.lazyLoadThreshold)
 
     @triggerImageLoad = (slide, imageElement, index) ->
       @trigger 'uiGalleryImageLoad',
@@ -55,5 +52,5 @@ define [
         element.removeAttr 'data-src'
 
     @after 'initialize', ->
-      @on 'uiGalleryContentReady', @initialLoad
+      @on 'uiGalleryContentReady', @lazyLoad
       @on 'uiGalleryLazyLoadRequested', @lazyLoad

--- a/dist/components/ui/image_loader.js
+++ b/dist/components/ui/image_loader.js
@@ -4,11 +4,8 @@ define(['jquery', 'flight/lib/component'], function($, defineComponent) {
       errorUrl: void 0,
       lazyLoadThreshold: void 0
     });
-    this.initialLoad = function() {
-      return this.loadImages(this.attr.lazyLoadThreshold);
-    };
     this.lazyLoad = function() {
-      return this.loadImages();
+      return this.loadImages(this.attr.lazyLoadThreshold);
     };
     this.triggerImageLoad = function(slide, imageElement, index) {
       return this.trigger('uiGalleryImageLoad', {
@@ -47,7 +44,7 @@ define(['jquery', 'flight/lib/component'], function($, defineComponent) {
       })(this));
     };
     return this.after('initialize', function() {
-      this.on('uiGalleryContentReady', this.initialLoad);
+      this.on('uiGalleryContentReady', this.lazyLoad);
       return this.on('uiGalleryLazyLoadRequested', this.lazyLoad);
     });
   });


### PR DESCRIPTION
- Lazy loading now honors the threshold when `uiGalleryLazyLoadRequested` is triggered.

Previously, the gallery would load the first images set by `attr.lazyLoadThreshold` then load ALL of the remaining. This fixes that bug.

[Story](91500142)
