### PR TITLE
[CW] [84627707] Fix backwards image loader for IE8

### DIFF
--- a/app/coffeescript/components/ui/image_loader.coffee
+++ b/app/coffeescript/components/ui/image_loader.coffee
@@ -40,7 +40,14 @@ define [
         height:       imageElement.height
 
     @loadImages = (begin, end) ->
-      @$node.find("[data-src]").slice(begin, end).each (index, element) =>
+      if end
+        elements = @$node.find("[data-src]").slice(begin, end)
+      else
+        # Normally, you can set `end` to `undefined` and it will work like it
+        # was not set. But IE8 does not behave this way.
+        elements = @$node.find("[data-src]").slice(begin)
+
+      elements.each (index, element) =>
         element = $(element)
 
         if element.prop('tagName') is 'IMG'

--- a/dist/components/ui/image_loader.js
+++ b/dist/components/ui/image_loader.js
@@ -27,7 +27,13 @@ define(['jquery', 'flight/lib/component'], function($, defineComponent) {
       });
     };
     this.loadImages = function(begin, end) {
-      return this.$node.find("[data-src]").slice(begin, end).each((function(_this) {
+      var elements;
+      if (end) {
+        elements = this.$node.find("[data-src]").slice(begin, end);
+      } else {
+        elements = this.$node.find("[data-src]").slice(begin);
+      }
+      return elements.each((function(_this) {
         return function(index, element) {
           var imageElement;
           element = $(element);


### PR DESCRIPTION
- IE8 does not use Array#slice the same.

[Story](https://www.pivotaltracker.com/story/show/84627706)
