### PR TITLE
[CW] [83903408] Fix IE8 onload and detecting image index

### DIFF
--- a/dist/components/ui/image_loader.js
+++ b/dist/components/ui/image_loader.js
@@ -4,6 +4,15 @@ define(['jquery', 'flight/lib/component'], function($, defineComponent) {
       errorUrl: void 0,
       lazyLoadThreshold: void 0
     });
+    this.assignIndex = function() {
+      return this.$node.find("[data-src]").each(function(index) {
+        var ele;
+        ele = $(this);
+        if (!ele.attr('data-index')) {
+          return ele.attr('data-index', index);
+        }
+      });
+    };
     this.lazyLoad = function(event, data) {
       var begin, direction, end, number;
       number = (data != null ? data.number : void 0) || this.attr.lazyLoadThreshold;
@@ -34,32 +43,38 @@ define(['jquery', 'flight/lib/component'], function($, defineComponent) {
         elements = this.$node.find("[data-src]").slice(begin);
       }
       return elements.each((function(_this) {
-        return function(index, element) {
-          var imageElement;
+        return function(_index, element) {
+          var imageElement, index;
           element = $(element);
+          index = parseInt(element.attr('data-index'), 10);
+          imageElement = new Image;
+          $(imageElement).on('load', function() {
+            return _this.triggerImageLoad(element, imageElement, index);
+          });
+          imageElement.src = element.attr('data-src');
           if (element.prop('tagName') === 'IMG') {
-            if (_this.attr.errorUrl) {
-              element.on('error', function() {
-                return element.attr('src', _this.attr.errorUrl);
-              });
-            }
-            element.on('load', function() {
-              return _this.triggerImageLoad(element, element[0], index);
-            });
-            element.attr('src', element.attr('data-src'));
+            return _this.setImageSrc(element);
           } else {
-            imageElement = new Image;
-            $(imageElement).on('load', function() {
-              return _this.triggerImageLoad(element, imageElement, index);
-            });
-            imageElement.src = element.attr('data-src');
-            element.css('background-image', "url(" + (element.attr('data-src')) + ")");
+            return _this.setBackgroundImageSrc(element);
           }
-          return element.removeAttr('data-src');
         };
       })(this));
     };
+    this.setImageSrc = function(element) {
+      if (this.attr.errorUrl) {
+        element.on('error', (function(_this) {
+          return function() {
+            return element.attr('src', _this.attr.errorUrl);
+          };
+        })(this));
+      }
+      return element.attr('src', element.attr('data-src')).removeAttr('data-src');
+    };
+    this.setBackgroundImageSrc = function(element) {
+      return element.css('background-image', "url(" + (element.attr('data-src')) + ")").removeAttr('data-src');
+    };
     return this.after('initialize', function() {
+      this.on('uiGalleryContentReady', this.assignIndex);
       this.on('uiGalleryContentReady', this.lazyLoad);
       return this.on('uiGalleryLazyLoadRequested', this.lazyLoad);
     });

--- a/test/spec/components/ui/image_loader_spec.coffee
+++ b/test/spec/components/ui/image_loader_spec.coffee
@@ -8,11 +8,11 @@ define [ 'jquery' ], ($) ->
         @component.$node.trigger('uiGalleryContentReady')
 
       it "initially sets src of first images to data-src", ->
-        expected = '<img src="foo"><img src="bar"><img data-src="barney"><img data-src="baz">'
+        expected = '<img data-index="0" src="foo"><img data-index="1" src="bar"><img data-src="barney" data-index="2"><img data-src="baz" data-index="3">'
         expect(@component.$node.html()).toEqual(expected)
 
       it "sets src of remaining images to data-src when uiGalleryLazyLoadRequested", ->
-        expected = '<img src="foo"><img src="bar"><img src="barney"><img src="baz">'
+        expected = '<img data-index="0" src="foo"><img data-index="1" src="bar"><img data-index="2" src="barney"><img data-index="3" src="baz">'
         @component.$node.trigger('uiGalleryLazyLoadRequested')
         expect(@component.$node.html()).toEqual(expected)
 
@@ -20,7 +20,7 @@ define [ 'jquery' ], ($) ->
       it "initially sets src of all images to data-src", ->
         @setupComponent(fixture)
         @component.$node.trigger('uiGalleryContentReady')
-        expected = '<img src="foo"><img src="bar"><img src="barney"><img src="baz">'
+        expected = '<img data-index="0" src="foo"><img data-index="1" src="bar"><img data-index="2" src="barney"><img data-index="3" src="baz">'
         expect(@component.$node.html()).toEqual(expected)
 
     describe 'triggering load events', ->
@@ -89,3 +89,12 @@ define [ 'jquery' ], ($) ->
             expected = '<img data-src="foo"><img src="bar"><img src="barney"><img src="baz">'
             @component.lazyLoad null, { number: 3, direction: 'backward' }
             expect(@component.$node.html()).toEqual(expected)
+
+    describe '#assignIndex', ->
+        beforeEach ->
+          @setupComponent fixture
+
+        it "assigns data-index", ->
+          expected = '<img data-src="foo" data-index="0"><img data-src="bar" data-index="1"><img data-src="barney" data-index="2"><img data-src="baz" data-index="3">'
+          @component.assignIndex()
+          expect(@component.$node.html()).toEqual(expected)


### PR DESCRIPTION
- Switch onload detection to always use a new image
- Fix index of images when loaded by using `data-index`

IE8 does not always fire `onload` when an image is already in the DOM. Switching new a new Image (like the background-image version) fixes this.

When lazy load runs, the index was reset each time based on what was loaded. This switches to `data-index` which is set once.

[Story](https://www.pivotaltracker.com/story/show/83903408)
