### PR TITLE
[MTS/LT][96823634] Fix thumbnail group transitions

### DIFF
--- a/app/coffeescript/components/mixins/gallery_utils.coffee
+++ b/app/coffeescript/components/mixins/gallery_utils.coffee
@@ -15,7 +15,15 @@ define [
     # data.speed is optional int (milliseconds)
     @goToIndex = (event, data) ->
       unless data.index is @activeIndex()
-        @swiper.swipeTo(data.index, data.speed)
+        $node = @$node
+        if $node.is(':visible')
+          @swiper.swipeTo(data.index, data.speed)
+        else
+          # We must show the thumbnail tray briefly so that Swiper can calculate
+          # the current slide position correctly.
+          $node.show()
+          @swiper.swipeTo(data.index, data.speed)
+          $node.hide()
 
     @activeIndex = ->
       if @swiper.params.loop then @swiper.activeLoopIndex else @swiper.activeIndex

--- a/dist/components/mixins/gallery_utils.js
+++ b/dist/components/mixins/gallery_utils.js
@@ -11,8 +11,16 @@ define([], function() {
       slideClass: ''
     };
     this.goToIndex = function(event, data) {
+      var $node;
       if (data.index !== this.activeIndex()) {
-        return this.swiper.swipeTo(data.index, data.speed);
+        $node = this.$node;
+        if ($node.is(':visible')) {
+          return this.swiper.swipeTo(data.index, data.speed);
+        } else {
+          $node.show();
+          this.swiper.swipeTo(data.index, data.speed);
+          return $node.hide();
+        }
       }
     };
     return this.activeIndex = function() {

--- a/test/spec/components/mixins/gallery_utils_spec.coffee
+++ b/test/spec/components/mixins/gallery_utils_spec.coffee
@@ -14,7 +14,6 @@ define [], () ->
         @component.swiper.activeIndex = 7
         expect(@component.activeIndex()).toEqual(7)
 
-
     describe 'goToIndex()', ->
       it 'does nothing if data.index is the active index', ->
         @component.activeIndex = -> 42
@@ -22,8 +21,28 @@ define [], () ->
         @component.goToIndex(null, {index: 42})
         expect(@component.swiper.swipeTo).not.toHaveBeenCalled()
 
-      it 'calls @swiper.swipeTo() if data.index is not the active index', ->
-        @component.activeIndex = -> 42
-        spyOn(@component.swiper, 'swipeTo')
-        @component.goToIndex(null, {index: 1, speed: 2})
-        expect(@component.swiper.swipeTo).toHaveBeenCalledWith(1, 2)
+      describe 'when data.index is not the active index', ->
+        beforeEach ->
+          @component.activeIndex = -> 42
+
+        it 'calls @swiper.swipeTo()', ->
+          spyOn(@component.swiper, 'swipeTo')
+          @component.goToIndex(null, {index: 1, speed: 2})
+          expect(@component.swiper.swipeTo).toHaveBeenCalledWith(1, 2)
+
+        describe 'a hack for ensuring correct swiping behavior in Chrome', ->
+          it 'quickly shows and hides the tray if the tray is not visible', ->
+            @component.$node.hide() # Make tray invisible
+            spyOn(@component.$node, 'show')
+            spyOn(@component.$node, 'hide')
+            @component.goToIndex(null, {index: 1, speed: 2})
+            expect(@component.$node.show).toHaveBeenCalled()
+            expect(@component.$node.hide).toHaveBeenCalled()
+
+          it 'does not hide the tray if the tray is visible', ->
+            spyOn(@component.$node, 'show')
+            spyOn(@component.$node, 'hide')
+            @component.goToIndex(null, {index: 1, speed: 2})
+            expect(@component.$node.show).not.toHaveBeenCalled()
+            expect(@component.$node.hide).not.toHaveBeenCalled()
+


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/96823634

When you used the main image gallery controls to transition from one
image to the next, the thumbnail groups would keep in sync with the
main images. This did not work when transitioning from the second
thumbnail group back to the first thumbnail group. The problem happened
only when the thumbnails were hidden. Swiper relied on WebKitCSSMatrix,
which wasn't returning the values we wanted when the thumbnails weren't
visibe. See
https://github.com/nolimits4web/Swiper/blob/v2.7.5/src/idangerous.swiper.js#L2575
if you're interested in Swiper's implementation.

Our solution is to show the drawer, let Swiper do its calculations, and
then hide the drawer. This happens fast enough that the user can't see
the drawer being shown, and then hidden again.
- [x] Specs pass

CC: @c0 
